### PR TITLE
RSDK-4714 virtualenv setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+MODULE_DIR=$(dirname $0)
+VIRTUAL_ENV=$MODULE_DIR/.venv
+PYTHON=$VIRTUAL_ENV/bin/python

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     - name: build
       run: make module.tar.gz
     - name: upload ARM
-      # if: ${{ github.event_name == 'release' }}
+      if: ${{ github.event_name == 'release' }}
       uses: viamrobotics/upload-module@main
       with:
         module-path: module.tar.gz
@@ -22,7 +22,7 @@ jobs:
         version: ${{ env.VERSION }}
         cli-config-secret: ${{ secrets.cli_config }}
     - name: upload x86
-      # if: ${{ github.event_name == 'release' }}
+      if: ${{ github.event_name == 'release' }}
       uses: viamrobotics/upload-module@main
       with:
         module-path: module.tar.gz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: build
       run: make module.tar.gz
-    # publish for ARM devices
-    - name: upload
+    - name: upload ARM
       # if: ${{ github.event_name == 'release' }}
       uses: viamrobotics/upload-module@main
       with:
@@ -22,8 +21,7 @@ jobs:
         platform: linux/arm64
         version: ${{ env.VERSION }}
         cli-config-secret: ${{ secrets.cli_config }}
-    # publish for Intel devices
-    - name: upload
+    - name: upload x86
       # if: ${{ github.event_name == 'release' }}
       uses: viamrobotics/upload-module@main
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,32 +4,27 @@ on:
     types: [published]
 
 jobs:
-  # build step runs on every push
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: build
-      run: tar czf module.tar.gz exec.sh src requirements.txt # <-- your build command goes here
-    - uses: actions/upload-artifact@v3
-      with:
-        name: module
-        path: module.tar.gz
-
-  # publish step only runs on release
-  publish:
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'release' }}
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/download-artifact@v3 # consume built module from 'build' job
-      with:
-        name: module
+      run: make module.tar.gz
+    # publish for ARM devices
     - name: upload
+      if: ${{ github.event_name == 'release' }}
       uses: viamrobotics/upload-module@main
       with:
         module-path: module.tar.gz
-        org-id: 19d1d286-c024-4d7a-ab9f-38cc2600eb42 # <-- replace with your org ID
         platform: linux/arm64
+        version: ${{ github.ref_name }}
+        cli-config-secret: ${{ secrets.cli_config }}
+    # publish for Intel devices
+    - name: upload
+      if: ${{ github.event_name == 'release' }}
+      uses: viamrobotics/upload-module@main
+      with:
+        module-path: module.tar.gz
+        platform: linux/amd64
         version: ${{ github.ref_name }}
         cli-config-secret: ${{ secrets.cli_config }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,14 +13,14 @@ jobs:
     - uses: actions/checkout@v3
     - name: build
       run: make module.tar.gz
-    # - name: upload ARM
-    #   if: ${{ github.event_name == 'release' }}
-    #   uses: viamrobotics/upload-module@main
-    #   with:
-    #     module-path: module.tar.gz
-    #     platform: linux/arm64
-    #     version: ${{ env.VERSION }}
-    #     cli-config-secret: ${{ secrets.cli_config }}
+    - name: upload ARM
+      # if: ${{ github.event_name == 'release' }}
+      uses: viamrobotics/upload-module@main
+      with:
+        module-path: module.tar.gz
+        platform: linux/arm64
+        version: ${{ env.VERSION }}
+        cli-config-secret: ${{ secrets.cli_config }}
     - name: upload x86
       # if: ${{ github.event_name == 'release' }}
       uses: viamrobotics/upload-module@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,14 +13,14 @@ jobs:
     - uses: actions/checkout@v3
     - name: build
       run: make module.tar.gz
-    - name: upload ARM
-      # if: ${{ github.event_name == 'release' }}
-      uses: viamrobotics/upload-module@main
-      with:
-        module-path: module.tar.gz
-        platform: linux/arm64
-        version: ${{ env.VERSION }}
-        cli-config-secret: ${{ secrets.cli_config }}
+    # - name: upload ARM
+    #   if: ${{ github.event_name == 'release' }}
+    #   uses: viamrobotics/upload-module@main
+    #   with:
+    #     module-path: module.tar.gz
+    #     platform: linux/arm64
+    #     version: ${{ env.VERSION }}
+    #     cli-config-secret: ${{ secrets.cli_config }}
     - name: upload x86
       # if: ${{ github.event_name == 'release' }}
       uses: viamrobotics/upload-module@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,9 @@ on:
   release:
     types: [published]
 
+env:
+  VERSION: ${{ github.event_name == 'release' && github.ref_name || format('0.0.0-{0}.{1}', github.ref_name, github.run_number) }}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -12,19 +15,19 @@ jobs:
       run: make module.tar.gz
     # publish for ARM devices
     - name: upload
-      if: ${{ github.event_name == 'release' }}
+      # if: ${{ github.event_name == 'release' }}
       uses: viamrobotics/upload-module@main
       with:
         module-path: module.tar.gz
         platform: linux/arm64
-        version: ${{ github.ref_name }}
+        version: ${{ env.VERSION }}
         cli-config-secret: ${{ secrets.cli_config }}
     # publish for Intel devices
     - name: upload
-      if: ${{ github.event_name == 'release' }}
+      # if: ${{ github.event_name == 'release' }}
       uses: viamrobotics/upload-module@main
       with:
         module-path: module.tar.gz
         platform: linux/amd64
-        version: ${{ github.ref_name }}
+        version: ${{ env.VERSION }}
         cli-config-secret: ${{ secrets.cli_config }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+on:
+  push:
+
+jobs:
+  # test virtualenv setup on raw debian image
+  test-venv:
+    runs-on: ubuntu-latest
+    container: debian:bullseye
+    steps:
+    - uses: actions/checkout@v3
+    - name: test initial install
+      run: |
+        ./setup.sh
+        .venv/bin/python -c "import viam"
+    - name: test reinstall case
+      run: |
+        ./setup.sh
+        .venv/bin/python -c "import viam"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,6 @@ jobs:
       run: |
         ./setup.sh
         .venv/bin/python -c "import viam"
-  test-make:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: exercise bundle command
-      run: make module.tar.gz
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,9 @@ jobs:
       run: |
         ./setup.sh
         .venv/bin/python -c "import viam"
+  test-make:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: exercise bundle command
+      run: make module.tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,14 @@ jobs:
     - uses: actions/checkout@v3
     - name: exercise bundle command
       run: make module.tar.gz
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: install
+      run: pip install ruff
+    - name: lint
+      run: ruff check src

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 *.tar.gz
+.venv/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+module.tar.gz:
+	tar czf $@ *.sh .env src requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Python example module
+
+This is an example of a Viam module using our Python SDK. This repo shows how to:
+
+- Use a Python virtualenv to install your module's dependencies on the robot
+- Write a simple module in Python
+- Use CI to automatically publish a new version when you create a Github release
+
+## Forking this repo
+
+If you want to copy this repo and run it yourself, you'll need to make a few changes:
+
+### Create your own meta.json
+
+1. Get the Viam CLI (todo: link to docs)
+1. Rename the existing `meta.json` to `meta.json.old`
+1. Use `viam module create` to create a copy in your own account
+1. Copy all the fields except `name` from meta.json.old (your choice whether to make it public or private)
+
+### Change all references to the `viam` namespace
+
+You'll need to change all the namespace references in the codebase ('viam') to the namespace of your organization on Viam.
+
+1. You should already have done this in meta.json above
+1. In the "model" field in meta.json (on line 9 when this was written)
+1. In the ModelFamily in wifi_sensor.py, [around here](src/wifi_sensor.py#L13).
+
+### Set a secret if you want to use Github CI
+
+Instructions for setting the secret are [here](https://github.com/viamrobotics/upload-module#setting-cli-config-secret).

--- a/exec.sh
+++ b/exec.sh
@@ -3,8 +3,8 @@
 # bash safe mode. look at `set --help` to see what these are doing
 set -euxo pipefail 
 
+cd $(dirname $0)
 source .env
-cd $MODULE_DIR
 ./setup.sh
 
 # Be sure to use `exec` so that termination signals reach the python process,

--- a/exec.sh
+++ b/exec.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
-cd `dirname $0`
+
+# bash safe mode. look at `set --help` to see what these are doing
 set -euxo pipefail 
-# python -m venv env
-# source env/bin/activate
-sudo apt-get update
-sudo apt-get install -y python3-pip
-pip3 install -r requirements.txt
+
+./setup.sh
+source .env
+
+cd $MODULE_DIR
+ENTRYPOINT=src.main
 
 # Be sure to use `exec` so that termination signals reach the python process,
 # or handle forwarding termination signals manually
-exec python3 -m src.main $@
-# deactivate
+exec $PYTHON -m $ENTRYPOINT $@

--- a/exec.sh
+++ b/exec.sh
@@ -3,12 +3,10 @@
 # bash safe mode. look at `set --help` to see what these are doing
 set -euxo pipefail 
 
-./setup.sh
 source .env
-
 cd $MODULE_DIR
-ENTRYPOINT=src.main
+./setup.sh
 
 # Be sure to use `exec` so that termination signals reach the python process,
 # or handle forwarding termination signals manually
-exec $PYTHON -m $ENTRYPOINT $@
+exec $PYTHON -m src.main $@

--- a/meta.json
+++ b/meta.json
@@ -1,12 +1,12 @@
 {
-  "name": "fahmina:wifi-sensor",
+  "name": "viam:python-example-module",
   "visibility": "public",
   "url": "https://github.com/Fahmina/wifi-sensor",
   "description": "This is a sensor that exposes wifi network, signal strength, and noise which is available via proc/net/wireless on linux",
   "models": [
     {
       "api": "rdk:component:sensor",
-      "model": "fahmina:wifi_sensor:linux"
+      "model": "viam:wifi_sensor:linux"
     }
   ],
   "entrypoint": "exec.sh"

--- a/package.sh
+++ b/package.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-tar -czf module.tar.gz --exclude=module.tar.gz .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.ruff]
+ignore = ["E501"]

--- a/setup.sh
+++ b/setup.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 # setup.sh -- environment bootstrapper for python virtualenv
 
+set -euo pipefail
+
+SUDO=sudo
+if ! command -v $SUDO; then
+	echo no sudo on this system, proceeding as current user
+	SUDO=""
+fi
+
 if command -v apt-get; then
 	if dpkg -l python3-venv; then
 		echo "python3-venv is installed, skipping setup"
 	else
 		if ! apt info python3-venv; then
 			echo package info not found, trying apt update
-			sudo apt-get update
+			$SUDO apt-get update
 		fi
-		sudo apt-get install -qqy python3-venv
+		$SUDO apt-get install -qqy python3-venv
 	fi
 else
 	echo Skipping tool installation because your platform is missing apt-get.
@@ -18,6 +26,6 @@ fi
 
 source .env
 echo creating virtualenv at $VIRTUAL_ENV
-python -m venv $VIRTUAL_ENV
+python3 -m venv $VIRTUAL_ENV
 echo installing dependencies from requirements.txt
 $VIRTUAL_ENV/bin/pip install -r requirements.txt

--- a/setup.sh
+++ b/setup.sh
@@ -15,7 +15,7 @@ if command -v apt-get; then
 	else
 		if ! apt info python3-venv; then
 			echo package info not found, trying apt update
-			$SUDO apt-get update
+			$SUDO apt-get -qq update
 		fi
 		$SUDO apt-get install -qqy python3-venv
 	fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# setup.sh -- environment bootstrapper for python virtualenv
+
+if command -v apt-get; then
+	if dpkg -l python3-venv; then
+		echo "python3-venv is installed, skipping setup"
+	else
+		if ! apt info python3-venv; then
+			echo package info not found, trying apt update
+			sudo apt-get update
+		fi
+		sudo apt-get install -qqy python3-venv
+	fi
+else
+	echo Skipping tool installation because your platform is missing apt-get.
+	echo If you see failures below, install the equivalent of python3-venv for your system.
+fi
+
+source .env
+echo creating virtualenv at $VIRTUAL_ENV
+python -m venv $VIRTUAL_ENV
+echo installing dependencies from requirements.txt
+$VIRTUAL_ENV/bin/pip install -r requirements.txt

--- a/src/wifi_sensor.py
+++ b/src/wifi_sensor.py
@@ -2,7 +2,6 @@ import asyncio
 from typing import Any, ClassVar, Dict, Mapping, Optional
 from typing_extensions import Self
 from viam.components.sensor import Sensor
-from viam.operations import run_with_operation
 from viam.proto.app.robot import ComponentConfig
 from viam.proto.common import ResourceName
 from viam.resource.base import ResourceBase

--- a/src/wifi_sensor.py
+++ b/src/wifi_sensor.py
@@ -9,7 +9,7 @@ from viam.resource.types import Model, ModelFamily
 
 class MySensor(Sensor):
     # Subclass the Viam Arm component and implement the required functions
-    MODEL: ClassVar[Model] = Model(ModelFamily("fahmina","wifi_sensor"), "linux")
+    MODEL: ClassVar[Model] = Model(ModelFamily("viam", "wifi_sensor"), "linux")
 
     @classmethod
     def new(cls, config: ComponentConfig, dependencies: Mapping[ResourceName, ResourceBase]) -> Self:


### PR DESCRIPTION
## What changed
- setup.sh in exec.sh to set up virtualenv
  - if the system doesn't have apt-get, it assumes you've already installed python3-venv
  - if the python3-venv package is already present, it doesn't reinstall it (but it does reinstall the requirements.txt)
  - added a CI step to test setup.sh on a bare debian image
- multi-architecture builds (arm + x86 linux)
- moved module to `viam` namespace
- Makefile
- README.md
## Tests
- new CI
- installed the module on viam-server running on my laptop, it works (https://app.viam.com/module/viam/python-example-module version `0.0.0-venv.6`)